### PR TITLE
Refactor project into standard Python package structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+
+# Virtual environments
+venv/
+.env/
+
+# PyInstaller
+*.spec
+
+# macOS
+.DS_Store
+
+# Logs
+*.log
+
+# IDE settings
+.vscode/
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# iPhone WDA Mirror
+
+通过 [WebDriverAgent](https://github.com/appium/WebDriverAgent) 获取 iPhone 屏幕并使用鼠标控制设备。本项目整理为标准的 Python `src` 目录结构，方便二次开发与分发。
+
+## 安装
+
+1. 确保设备已经部署并启动 WDA 服务，USB 连接时可使用 `iproxy 8100 8100` 转发端口。
+2. 安装依赖：
+
+```bash
+pip install -r requirements.txt
+```
+
+## 使用
+
+运行模块即可启动镜像窗口：
+
+```bash
+python -m iphone_wda_mirror
+```
+
+窗口中左键点击相当于点按，按住拖动可以实现滑动，按 `Esc` 或 `q` 退出。
+
+如需固定附着某个 App，可编辑 `src/iphone_wda_mirror/mirror.py` 中的 `TARGET_BUNDLE`。默认附着当前前台应用。
+
+## 目录结构
+
+```
+.
+├── README.md
+├── requirements.txt
+├── src
+│   └── iphone_wda_mirror
+│       ├── __init__.py
+│       ├── __main__.py
+│       └── mirror.py
+└── tests
+```
+
+## 许可证
+
+MIT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "iphone-wda-mirror"
+version = "0.1.0"
+description = "Mirror iPhone screen via WebDriverAgent and control with mouse"
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "requests",
+    "opencv-python",
+    "numpy",
+    "python-wda",
+]
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+requests
+opencv-python
+numpy
+python-wda

--- a/src/iphone_wda_mirror/__init__.py
+++ b/src/iphone_wda_mirror/__init__.py
@@ -1,0 +1,5 @@
+"""iPhone WDA mirror package."""
+
+from .mirror import main
+
+__all__ = ["main"]

--- a/src/iphone_wda_mirror/__main__.py
+++ b/src/iphone_wda_mirror/__main__.py
@@ -1,0 +1,4 @@
+from .mirror import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- reorganize code into a `src` based package with entrypoint
- add dependency configuration, README and gitignore
- provide minimal packaging via `pyproject.toml`

## Testing
- `python -m py_compile $(find src -name '*.py')`
- `PYTHONPATH=src python -m iphone_wda_mirror` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68af246e49c483239c8b132d9ecc2d01