### PR TITLE
fix: correct wda dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "requests",
     "opencv-python",
     "numpy",
-    "python-wda",
+    "wda",
 ]
 
 [build-system]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests
 opencv-python
 numpy
-python-wda
+wda


### PR DESCRIPTION
## Summary
- replace nonexistent python-wda dependency with wda

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af2a49baa88323b99dbc094be61a43