### PR TITLE
Add missing six dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "opencv-python",
     "numpy",
     "wda",
+    "six",
 ]
 
 [build-system]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 opencv-python
 numpy
 wda
+six


### PR DESCRIPTION
## Summary
- include `six` in project and requirements to satisfy `wda` dependency

## Testing
- `pytest`
- `python -m iphone_wda_mirror` *(fails: Connection refused to WDA server)*

------
https://chatgpt.com/codex/tasks/task_e_68af3000f6f08323b1750a94dd3f1299